### PR TITLE
Bumping to 0.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
-# 0.2.1 (2026-02-04)
+# 0.3.0 (2026-02-04)
 
 - Add `URIs::HeadCheck`, an OkComputer check that performs a HEAD request
   to verify the availability of a URL, with optional basic authentication.
 - updates Requester to support timeouts values passed to RestClient
+- Bumping to 0.3.0 to reflect changes to `Requester` and the addition of `URIs::HeadCheck`.
 
 # 0.2.0 (2025-07-24)
 

--- a/lib/berkeley_library/util/module_info.rb
+++ b/lib/berkeley_library/util/module_info.rb
@@ -7,7 +7,7 @@ module BerkeleyLibrary
       SUMMARY = 'Miscellaneous Ruby utilities for the UC Berkeley Library'.freeze
       DESCRIPTION = 'A collection of miscellaneous Ruby routines for the UC Berkeley Library.'.freeze
       LICENSE = 'MIT'.freeze
-      VERSION = '0.2.1'.freeze
+      VERSION = '0.3.0'.freeze
       HOMEPAGE = 'https://github.com/BerkeleyLibrary/util'.freeze
     end
   end


### PR DESCRIPTION
Bumping to 0.3.0 to reflect changes to `Requester` and the addition of `URIs::HeadCheck`.